### PR TITLE
Improve dockerfile

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -77,7 +77,10 @@ jobs:
           version=$(/opt/iconik/iconik_storage_gateway/iconik_storage_gateway --version | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
           echo "Version: ${version}"
           echo "version=${version}" >> $GITHUB_OUTPUT
-          [ -z "$version" ] && { echo "Failed to get version"; exit 1; }
+          if [ -z "$version" ]; then
+            echo "Failed to get version"
+            exit 1
+          fi
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           sudo ./install-iconik.sh
           echo "Getting version"
-          echo icoik-storage-gateway --version
+          echo iconik-storage-gateway --version
           version=$(iconik-storage-gateway --version | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
           echo "Version: ${version}"
           echo "version=${version}" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,8 +72,8 @@ jobs:
         run: |
           sudo ./install-iconik.sh
           echo "Getting version"
-          echo iconik-storage-gateway --version
-          version=$(iconik-storage-gateway --version | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
+          echo $(/opt/iconik/iconik_storage_gateway/iconik_storage_gateway --version)
+          version=$(/opt/iconik/iconik_storage_gateway/iconik_storage_gateway --version | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
           echo "Version: ${version}"
           echo "version=${version}" >> $GITHUB_OUTPUT
           [ -z "$version" ] && { echo "Failed to get version"; exit 1; }

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Get Version
         id: get_version
+        shell: bash
         run: |
           sudo ./install-iconik.sh
           echo "Getting version"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Get Version
         id: get_version
         run: |
-          ./install-iconik.sh
+          sudo ./install-iconik.sh
           echo "Getting version"
           echo icoik-storage-gateway --version
           version=$(iconik-storage-gateway --version | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,13 +7,13 @@ name: Docker
 
 on:
   schedule:
-    - cron: '32 18 * * *'
+    - cron: "32 18 * * *"
   push:
-    branches: [ "master" ]
+    branches: ["master"]
     # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags: ["v*.*.*"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -21,10 +21,8 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -43,7 +41,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
         with:
-          cosign-release: 'v2.2.4'
+          cosign-release: "v2.2.4"
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
@@ -69,6 +67,17 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Get Version
+        id: get_version
+        run: |
+          ./install-iconik.sh
+          echo "Getting version"
+          echo icoik-storage-gateway --version
+          version=$(iconik-storage-gateway --version | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
+          echo "Version: ${version}"
+          echo "version=${version}" >> $GITHUB_OUTPUT
+          [ -z "$version" ] && { echo "Failed to get version"; exit 1; }
+
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
@@ -77,7 +86,10 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.version }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN /tmp/install-iconik.sh
 RUN \
     chmod 777 -R /opt/iconik && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    rm /tmp/install-iconik.sh
 
 VOLUME /var/iconik/iconik_storage_gateway/data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ RUN apt-get update && \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG=en_US.utf8
 
-ARG REPO_BASE=https://packages.iconik.io/deb/ubuntu
-
 COPY ./install-iconik.sh /tmp/install-iconik.sh
 RUN /tmp/install-iconik.sh
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ ARG REPO_BASE=https://packages.iconik.io/deb/ubuntu
 COPY ./install-iconik.sh /tmp/install-iconik.sh
 RUN /tmp/install-iconik.sh
 RUN \
-    chmod 777 -R /opt/iconik && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     rm /tmp/install-iconik.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,9 @@ ENV LANG=en_US.utf8
 
 ARG REPO_BASE=https://packages.iconik.io/deb/ubuntu
 
-RUN apt-get update && apt-get install -y wget gnupg && \
-    wget -O - ${REPO_BASE}/dists/jammy/iconik_package_repos_pub.asc | apt-key add - && \
-    echo "deb [trusted=yes] ${REPO_BASE} ./jammy main" > /etc/apt/sources.list.d/iconik.list && \
-    apt-get update && \
-    apt-get install -y iconik-storage-gateway && \
+COPY ./install-iconik.sh /tmp/install-iconik.sh
+RUN /tmp/install-iconik.sh
+RUN \
     chmod 777 -R /opt/iconik && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:jammy
-MAINTAINER iconik Media AB <info@iconik.io>
+
+LABEL org.opencontainers.image.authors="dev@ixsystems.com"
+
 RUN apt-get update && \
     apt-get install -y ffmpeg imagemagick poppler-utils ghostscript dcraw exiftool locales && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-ENV LANG en_US.utf8
+ENV LANG=en_US.utf8
 
 ARG REPO_BASE=https://packages.iconik.io/deb/ubuntu
 
@@ -11,9 +13,14 @@ RUN apt-get update && apt-get install -y wget gnupg && \
     wget -O - ${REPO_BASE}/dists/jammy/iconik_package_repos_pub.asc | apt-key add - && \
     echo "deb [trusted=yes] ${REPO_BASE} ./jammy main" > /etc/apt/sources.list.d/iconik.list && \
     apt-get update && \
-    apt-get install -y iconik-storage-gateway
+    apt-get install -y iconik-storage-gateway && \
+    chmod 777 -R /opt/iconik && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 VOLUME /var/iconik/iconik_storage_gateway/data
-CMD /opt/iconik/iconik_storage_gateway/iconik_storage_gateway \
+
+ENTRYPOINT /opt/iconik/iconik_storage_gateway/iconik_storage_gateway \
     --iconik-url=${ICONIK_URL:-https://app-lb.iconik.io/} \
     --auth-token=${AUTH_TOKEN} \
     --app-id=${APP_ID} \

--- a/install-iconik.sh
+++ b/install-iconik.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+REPO_BASE=https://packages.iconik.io/deb/ubuntu
+
+apt-get update && apt-get install -y wget gnupg
+wget -O - ${REPO_BASE}/dists/jammy/iconik_package_repos_pub.asc | apt-key add -
+echo "deb [trusted=yes] ${REPO_BASE} ./jammy main" >/etc/apt/sources.list.d/iconik.list
+apt-get update
+apt-get install -y iconik-storage-gateway


### PR DESCRIPTION
Additionally:
- Updates the maintainer to point to our mail, and uses the non-deprecated format
- Fixes env style deprecation
- Cleans apt to reduce image size, as it wont work afterwards without a privileged user
- Moves iconik binary installation into a seperate script, so we can also use it in CI to get the version to use in the tag

Now it will create the following tags:
`latest` and the version of the iconik binary, at the moment of writing, `3.11.3`